### PR TITLE
Fixed ignoring midi input port 1 or later

### DIFF
--- a/src/korg-nano-kontrol.es6
+++ b/src/korg-nano-kontrol.es6
@@ -68,7 +68,7 @@ function connectNodeMidi(deviceName){
           return resolve(new Device(input, name));
         }
       }
-      return reject("device not found");
     }
+    return reject("device not found");
   });
 }


### PR DESCRIPTION
I could not connect to the my nanoKONTROL2, because connectNodeMidi reject the promise after first midi input. So I moved reject() after checked each devices.And it's works fine.
